### PR TITLE
New update - read descript.

### DIFF
--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -45,6 +45,13 @@
 - name: Ensure postgresql is running
   service: name=postgresql state=started enabled=yes
 
+- name: Add titan postgresql user
+  become: yes
+  become_user: postgres
+  postgresql_user:
+    name: titan
+    state: present 
+
 - name: Initialize PostgreSQL DB
   become: yes
   become_user: postgres

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -40,7 +40,7 @@
     - psycopg2
     - alembic
     - eventlet
-    - gunicorn3
+    - gunicorn
     
 - name: Ensure postgresql is running
   service: name=postgresql state=started enabled=yes


### PR DESCRIPTION
No need for gunicorn3.

Ubuntu 18.04 is python3 by default.
Fixes postgres issues for 18.04